### PR TITLE
Adapt to android studio3.3

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="Kotlin2JvmCompilerArguments">
-    <option name="jvmTarget" value="1.8" />
-  </component>
-</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="CMakeSettings">
+    <configurations>
+      <configuration PROFILE_NAME="Debug" CONFIG_NAME="Debug" />
+    </configurations>
+  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,8 +2,8 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/DiceRoller.iml" filepath="$PROJECT_DIR$/DiceRoller.iml" />
       <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" />
+      <module fileurl="file://$PROJECT_DIR$/myDiceRoll.iml" filepath="$PROJECT_DIR$/myDiceRoll.iml" />
     </modules>
   </component>
 </project>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,6 +13,7 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        vectorDrawables.useSupportLibrary = true
     }
     buildTypes {
         release {

--- a/app/src/main/java/tokyo/cuttingedge/android/diceroller/MainActivity.kt
+++ b/app/src/main/java/tokyo/cuttingedge/android/diceroller/MainActivity.kt
@@ -3,11 +3,15 @@ package tokyo.cuttingedge.android.diceroller
 import android.support.v7.app.AppCompatActivity
 import android.os.Bundle
 import android.widget.Button
+import android.widget.ImageView
 import android.widget.TextView
 import android.widget.Toast
+import kotlinx.android.synthetic.main.activity_main.view.*
 import java.util.*
 
 class MainActivity : AppCompatActivity() {
+
+    lateinit var diceImage: ImageView
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -16,11 +20,26 @@ class MainActivity : AppCompatActivity() {
         rollButton.setOnClickListener {
             rollDice()
         }
+
+        diceImage = findViewById(R.id.dice_image)
     }
 
     private fun rollDice() {
         val randomInt = Random().nextInt(6) + 1
-        val resultText: TextView = findViewById(R.id.result_text)
-        resultText.text = randomInt.toString()
+        val drawableResource = when (randomInt){
+            1 -> R.drawable.dice_1
+            2 -> R.drawable.dice_2
+            3 -> R.drawable.dice_3
+            4 -> R.drawable.dice_4
+            5 -> R.drawable.dice_5
+            else -> R.drawable.dice_6
+        }
+
+        if (this::diceImage.isInitialized){
+            diceImage.setImageResource(drawableResource)
+        }
+
+
+
     }
 }

--- a/app/src/main/res/drawable/dice_1.xml
+++ b/app/src/main/res/drawable/dice_1.xml
@@ -1,0 +1,66 @@
+<!--
+  ~ Copyright 2018, The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="200dp"
+    android:height="250dp"
+    android:viewportWidth="800"
+    android:viewportHeight="1000">
+    <path
+        android:fillAlpha="0.5"
+        android:fillColor="#eee"
+        android:pathData="M740.8,635.42c-68.27,90.47 -249.77,201.76 -316,240.63a50.7,50.7 0,0 1,-49.93 0.81c-64.19,-35 -234.09,-133.88 -315.65,-242a14.69,14.69 0,0 1,-0.12 -17.49c77.58,-106.29 159.67,-258.89 341.06,-258.89 182,0 242.19,139.08 340.27,258.88A14.62,14.62 0,0 1,740.8 635.42Z"
+        android:strokeAlpha="0.5" />
+    <path
+        android:fillColor="#bdbdbd"
+        android:pathData="M704.9,630l-294.29,191.06l0,-340.85l294.29,-191.06l0,340.85z" />
+    <path
+        android:fillColor="#e0e0e0"
+        android:pathData="M97.59,630l294.29,191.06l0,-340.85l-294.29,-191.06l0,340.85z" />
+    <path
+        android:fillColor="#f5f5f5"
+        android:pathData="M400.14,464.73l-293.19,-191.45l293.19,-156.31l295.39,156.31l-295.39,191.45z" />
+    <path
+        android:fillColor="#eee"
+        android:pathData="M106.95,273.28l-9.36,15.87l294.29,191.06l8.26,-15.48l-293.19,-191.45z" />
+    <path
+        android:fillColor="#e0e0e0"
+        android:pathData="M695.53,273.28l9.37,15.87l-294.29,191.06l-10.47,-15.48l295.39,-191.45z" />
+    <path
+        android:fillColor="#eee"
+        android:pathData="M391.88,480.21h18.73v340.85h-18.73z" />
+    <path
+        android:fillColor="#f5f5f5"
+        android:pathData="M400.14,464.73l-8.26,15.48l18.73,0l-10.47,-15.48z" />
+    <path
+        android:fillColor="#78c257"
+        android:pathData="M397.45,297.62a16.9,28.71 97.07,1 0,4.16 -33.54a16.9,28.71 97.07,1 0,-4.16 33.54z" />
+    <path
+        android:fillColor="#78c257"
+        android:pathData="M297.17,539.02a30.12,16.11 53.82,1 0,26.01 -19.02a30.12,16.11 53.82,1 0,-26.01 19.02z" />
+    <path
+        android:fillColor="#78c257"
+        android:pathData="M161.96,588.24a30.12,16.11 53.82,1 0,26.01 -19.02a30.12,16.11 53.82,1 0,-26.01 19.02z" />
+    <path
+        android:fillColor="#78c257"
+        android:pathData="M551.15,579.45a30.12,16.11 126.18,1 0,35.56 -48.62a30.12,16.11 126.18,1 0,-35.56 48.62z" />
+    <path
+        android:fillColor="#78c257"
+        android:pathData="M469.12,549.58a30.12,16.11 126.18,1 0,35.56 -48.62a30.12,16.11 126.18,1 0,-35.56 48.62z" />
+    <path
+        android:fillColor="#78c257"
+        android:pathData="M633.17,609.29a30.12,16.11 126.18,1 0,35.56 -48.62a30.12,16.11 126.18,1 0,-35.56 48.62z" />
+</vector>

--- a/app/src/main/res/drawable/dice_2.xml
+++ b/app/src/main/res/drawable/dice_2.xml
@@ -1,0 +1,66 @@
+<!--
+  ~ Copyright 2018, The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="200dp"
+    android:height="250dp"
+    android:viewportWidth="800"
+    android:viewportHeight="1000">
+    <path
+        android:fillAlpha="0.5"
+        android:fillColor="#eee"
+        android:pathData="M740.8,635.42c-68.27,90.47 -249.77,201.76 -316,240.63a50.7,50.7 0,0 1,-49.93 0.81c-64.19,-35 -234.09,-133.88 -315.65,-242a14.69,14.69 0,0 1,-0.12 -17.49c77.58,-106.29 159.67,-258.89 341.06,-258.89 182,0 242.19,139.08 340.27,258.88A14.62,14.62 0,0 1,740.8 635.42Z"
+        android:strokeAlpha="0.5" />
+    <path
+        android:fillColor="#bdbdbd"
+        android:pathData="M704.9,630l-294.29,191.06l0,-340.85l294.29,-191.06l0,340.85z" />
+    <path
+        android:fillColor="#e0e0e0"
+        android:pathData="M97.59,630l294.29,191.06l0,-340.85l-294.29,-191.06l0,340.85z" />
+    <path
+        android:fillColor="#f5f5f5"
+        android:pathData="M400.14,464.73l-293.19,-191.45l293.19,-156.31l295.39,156.31l-295.39,191.45z" />
+    <path
+        android:fillColor="#eee"
+        android:pathData="M106.95,273.28l-9.36,15.87l294.29,191.06l8.26,-15.48l-293.19,-191.45z" />
+    <path
+        android:fillColor="#e0e0e0"
+        android:pathData="M695.53,273.28l9.37,15.87l-294.29,191.06l-10.47,-15.48l295.39,-191.45z" />
+    <path
+        android:fillColor="#eee"
+        android:pathData="M391.88,480.21h18.73v340.85h-18.73z" />
+    <path
+        android:fillColor="#f5f5f5"
+        android:pathData="M400.14,464.73l-8.26,15.48l18.73,0l-10.47,-15.48z" />
+    <path
+        android:fillColor="#78c257"
+        android:pathData="M520.85,303.25a16.9,28.71 97.07,1 0,4.16 -33.54a16.9,28.71 97.07,1 0,-4.16 33.54z" />
+    <path
+        android:fillColor="#78c257"
+        android:pathData="M273.33,291.99a16.9,28.71 97.07,1 0,4.16 -33.54a16.9,28.71 97.07,1 0,-4.16 33.54z" />
+    <path
+        android:fillColor="#78c257"
+        android:pathData="M229.56,563.64a30.12,16.11 53.82,1 0,26.01 -19.02a30.12,16.11 53.82,1 0,-26.01 19.02z" />
+    <path
+        android:fillColor="#78c257"
+        android:pathData="M311.58,533.77a30.12,16.11 53.82,1 0,26.01 -19.02a30.12,16.11 53.82,1 0,-26.01 19.02z" />
+    <path
+        android:fillColor="#78c257"
+        android:pathData="M147.54,593.49a30.12,16.11 53.82,1 0,26.01 -19.02a30.12,16.11 53.82,1 0,-26.01 19.02z" />
+    <path
+        android:fillColor="#78c257"
+        android:pathData="M551.15,579.45a30.12,16.11 126.18,1 0,35.56 -48.62a30.12,16.11 126.18,1 0,-35.56 48.62z" />
+</vector>

--- a/app/src/main/res/drawable/dice_3.xml
+++ b/app/src/main/res/drawable/dice_3.xml
@@ -1,0 +1,66 @@
+<!--
+  ~ Copyright 2018, The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="200dp"
+    android:height="250dp"
+    android:viewportWidth="800"
+    android:viewportHeight="1000">
+    <path
+        android:fillAlpha="0.5"
+        android:fillColor="#eee"
+        android:pathData="M740.8,635.42c-68.27,90.47 -249.77,201.76 -316,240.63a50.7,50.7 0,0 1,-49.93 0.81c-64.19,-35 -234.09,-133.88 -315.65,-242a14.69,14.69 0,0 1,-0.12 -17.49c77.58,-106.29 159.67,-258.89 341.06,-258.89 182,0 242.19,139.08 340.27,258.88A14.62,14.62 0,0 1,740.8 635.42Z"
+        android:strokeAlpha="0.5" />
+    <path
+        android:fillColor="#bdbdbd"
+        android:pathData="M704.9,630l-294.29,191.06l0,-340.85l294.29,-191.06l0,340.85z" />
+    <path
+        android:fillColor="#e0e0e0"
+        android:pathData="M97.59,630l294.29,191.06l0,-340.85l-294.29,-191.06l0,340.85z" />
+    <path
+        android:fillColor="#f5f5f5"
+        android:pathData="M400.14,464.73l-293.19,-191.45l293.19,-156.31l295.39,156.31l-295.39,191.45z" />
+    <path
+        android:fillColor="#eee"
+        android:pathData="M106.95,273.28l-9.36,15.87l294.29,191.06l8.26,-15.48l-293.19,-191.45z" />
+    <path
+        android:fillColor="#e0e0e0"
+        android:pathData="M695.53,273.28l9.37,15.87l-294.29,191.06l-10.47,-15.48l295.39,-191.45z" />
+    <path
+        android:fillColor="#eee"
+        android:pathData="M391.88,480.21h18.73v340.85h-18.73z" />
+    <path
+        android:fillColor="#f5f5f5"
+        android:pathData="M400.14,464.73l-8.26,15.48l18.73,0l-10.47,-15.48z" />
+    <path
+        android:fillColor="#78c257"
+        android:pathData="M398.11,297.62a16.9,28.71 97.07,1 0,4.16 -33.54a16.9,28.71 97.07,1 0,-4.16 33.54z" />
+    <path
+        android:fillColor="#78c257"
+        android:pathData="M548.27,304.46a16.9,28.71 97.07,1 0,4.16 -33.54a16.9,28.71 97.07,1 0,-4.16 33.54z" />
+    <path
+        android:fillColor="#78c257"
+        android:pathData="M247.95,290.79a16.9,28.71 97.07,1 0,4.16 -33.54a16.9,28.71 97.07,1 0,-4.16 33.54z" />
+    <path
+        android:fillColor="#78c257"
+        android:pathData="M229.56,563.64a30.12,16.11 53.82,1 0,26.01 -19.02a30.12,16.11 53.82,1 0,-26.01 19.02z" />
+    <path
+        android:fillColor="#78c257"
+        android:pathData="M483.54,554.83a30.12,16.11 126.18,1 0,35.56 -48.62a30.12,16.11 126.18,1 0,-35.56 48.62z" />
+    <path
+        android:fillColor="#78c257"
+        android:pathData="M618.75,604.04a30.12,16.11 126.18,1 0,35.56 -48.62a30.12,16.11 126.18,1 0,-35.56 48.62z" />
+</vector>

--- a/app/src/main/res/drawable/dice_4.xml
+++ b/app/src/main/res/drawable/dice_4.xml
@@ -1,0 +1,69 @@
+<!--
+  ~ Copyright 2018, The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="200dp"
+    android:height="250dp"
+    android:viewportWidth="800"
+    android:viewportHeight="1000">
+    <path
+        android:fillAlpha="0.5"
+        android:fillColor="#eee"
+        android:pathData="M740.8,635.42c-68.27,90.47 -249.77,201.76 -316,240.63a50.7,50.7 0,0 1,-49.93 0.81c-64.19,-35 -234.09,-133.88 -315.65,-242a14.69,14.69 0,0 1,-0.12 -17.49c77.58,-106.29 159.67,-258.89 341.06,-258.89 182,0 242.19,139.08 340.27,258.88A14.62,14.62 0,0 1,740.8 635.42Z"
+        android:strokeAlpha="0.5" />
+    <path
+        android:fillColor="#bdbdbd"
+        android:pathData="M704.9,630l-294.29,191.06l0,-340.85l294.29,-191.06l0,340.85z" />
+    <path
+        android:fillColor="#e0e0e0"
+        android:pathData="M97.59,630l294.29,191.06l0,-340.85l-294.29,-191.06l0,340.85z" />
+    <path
+        android:fillColor="#f5f5f5"
+        android:pathData="M400.14,464.73l-293.19,-191.45l293.19,-156.31l295.39,156.31l-295.39,191.45z" />
+    <path
+        android:fillColor="#eee"
+        android:pathData="M106.95,273.28l-9.36,15.87l294.29,191.06l8.26,-15.48l-293.19,-191.45z" />
+    <path
+        android:fillColor="#e0e0e0"
+        android:pathData="M695.53,273.28l9.37,15.87l-294.29,191.06l-10.47,-15.48l295.39,-191.45z" />
+    <path
+        android:fillColor="#eee"
+        android:pathData="M391.88,480.21h18.73v340.85h-18.73z" />
+    <path
+        android:fillColor="#f5f5f5"
+        android:pathData="M400.14,464.73l-8.26,15.48l18.73,0l-10.47,-15.48z" />
+    <path
+        android:fillColor="#78c257"
+        android:pathData="M530.08,303.65a16.9,28.71 97.07,1 0,4.16 -33.54a16.9,28.71 97.07,1 0,-4.16 33.54z" />
+    <path
+        android:fillColor="#78c257"
+        android:pathData="M389.68,218.17a16.9,28.71 97.07,1 0,4.16 -33.54a16.9,28.71 97.07,1 0,-4.16 33.54z" />
+    <path
+        android:fillColor="#78c257"
+        android:pathData="M405.35,377.09a16.9,28.71 97.07,1 0,4.16 -33.54a16.9,28.71 97.07,1 0,-4.16 33.54z" />
+    <path
+        android:fillColor="#78c257"
+        android:pathData="M264.95,291.6a16.9,28.71 97.07,1 0,4.16 -33.54a16.9,28.71 97.07,1 0,-4.16 33.54z" />
+    <path
+        android:fillColor="#78c257"
+        android:pathData="M297.17,541.59a30.12,16.11 53.82,1 0,26.01 -19.02a30.12,16.11 53.82,1 0,-26.01 19.02z" />
+    <path
+        android:fillColor="#78c257"
+        android:pathData="M161.96,590.81a30.12,16.11 53.82,1 0,26.01 -19.02a30.12,16.11 53.82,1 0,-26.01 19.02z" />
+    <path
+        android:fillColor="#78c257"
+        android:pathData="M551.15,579.45a30.12,16.11 126.18,1 0,35.56 -48.62a30.12,16.11 126.18,1 0,-35.56 48.62z" />
+</vector>

--- a/app/src/main/res/drawable/dice_5.xml
+++ b/app/src/main/res/drawable/dice_5.xml
@@ -1,0 +1,75 @@
+<!--
+  ~ Copyright 2018, The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="200dp"
+    android:height="250dp"
+    android:viewportWidth="800"
+    android:viewportHeight="1000">
+    <path
+        android:fillAlpha="0.5"
+        android:fillColor="#eee"
+        android:pathData="M740.8,635.42c-68.27,90.47 -249.77,201.76 -316,240.63a50.7,50.7 0,0 1,-49.93 0.81c-64.19,-35 -234.09,-133.88 -315.65,-242a14.69,14.69 0,0 1,-0.12 -17.49c77.58,-106.29 159.67,-258.89 341.06,-258.89 182,0 242.19,139.08 340.27,258.88A14.62,14.62 0,0 1,740.8 635.42Z"
+        android:strokeAlpha="0.5" />
+    <path
+        android:fillColor="#bdbdbd"
+        android:pathData="M704.9,630l-294.29,191.06l0,-340.85l294.29,-191.06l0,340.85z" />
+    <path
+        android:fillColor="#e0e0e0"
+        android:pathData="M97.59,630l294.29,191.06l0,-340.85l-294.29,-191.06l0,340.85z" />
+    <path
+        android:fillColor="#f5f5f5"
+        android:pathData="M400.14,464.73l-293.19,-191.45l293.19,-156.31l295.39,156.31l-295.39,191.45z" />
+    <path
+        android:fillColor="#eee"
+        android:pathData="M106.95,273.28l-9.36,15.87l294.29,191.06l8.26,-15.48l-293.19,-191.45z" />
+    <path
+        android:fillColor="#e0e0e0"
+        android:pathData="M695.53,273.28l9.37,15.87l-294.29,191.06l-10.47,-15.48l295.39,-191.45z" />
+    <path
+        android:fillColor="#eee"
+        android:pathData="M391.88,480.21h18.73v340.85h-18.73z" />
+    <path
+        android:fillColor="#f5f5f5"
+        android:pathData="M400.14,464.73l-8.26,15.48l18.73,0l-10.47,-15.48z" />
+    <path
+        android:fillColor="#78c257"
+        android:pathData="M397.05,297.63a16.9,28.71 97.07,1 0,4.16 -33.54a16.9,28.71 97.07,1 0,-4.16 33.54z" />
+    <path
+        android:fillColor="#78c257"
+        android:pathData="M547.21,304.45a16.9,28.71 97.07,1 0,4.16 -33.54a16.9,28.71 97.07,1 0,-4.16 33.54z" />
+    <path
+        android:fillColor="#78c257"
+        android:pathData="M388.17,207.62a16.9,28.71 97.07,1 0,4.16 -33.54a16.9,28.71 97.07,1 0,-4.16 33.54z" />
+    <path
+        android:fillColor="#78c257"
+        android:pathData="M405.93,387.62a16.9,28.71 97.07,1 0,4.16 -33.54a16.9,28.71 97.07,1 0,-4.16 33.54z" />
+    <path
+        android:fillColor="#78c257"
+        android:pathData="M246.89,290.79a16.9,28.71 97.07,1 0,4.16 -33.54a16.9,28.71 97.07,1 0,-4.16 33.54z" />
+    <path
+        android:fillColor="#78c257"
+        android:pathData="M229.56,563.64a30.12,16.11 53.82,1 0,26.01 -19.02a30.12,16.11 53.82,1 0,-26.01 19.02z" />
+    <path
+        android:fillColor="#78c257"
+        android:pathData="M551.15,579.45a30.12,16.11 126.18,1 0,35.56 -48.62a30.12,16.11 126.18,1 0,-35.56 48.62z" />
+    <path
+        android:fillColor="#78c257"
+        android:pathData="M469.12,549.58a30.12,16.11 126.18,1 0,35.56 -48.62a30.12,16.11 126.18,1 0,-35.56 48.62z" />
+    <path
+        android:fillColor="#78c257"
+        android:pathData="M633.17,609.29a30.12,16.11 126.18,1 0,35.56 -48.62a30.12,16.11 126.18,1 0,-35.56 48.62z" />
+</vector>

--- a/app/src/main/res/drawable/dice_6.xml
+++ b/app/src/main/res/drawable/dice_6.xml
@@ -1,0 +1,81 @@
+<!--
+  ~ Copyright 2018, The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="200dp"
+    android:height="250dp"
+    android:viewportWidth="800"
+    android:viewportHeight="1000">
+    <path
+        android:fillAlpha="0.5"
+        android:fillColor="#eee"
+        android:pathData="M740.8,635.42c-68.27,90.47 -249.77,201.76 -316,240.63a50.7,50.7 0,0 1,-49.93 0.81c-64.19,-35 -234.09,-133.88 -315.65,-242a14.69,14.69 0,0 1,-0.12 -17.49c77.58,-106.29 159.67,-258.89 341.06,-258.89 182,0 242.19,139.08 340.27,258.88A14.62,14.62 0,0 1,740.8 635.42Z"
+        android:strokeAlpha="0.5" />
+    <path
+        android:fillColor="#bdbdbd"
+        android:pathData="M704.9,630l-294.29,191.06l0,-340.85l294.29,-191.06l0,340.85z" />
+    <path
+        android:fillColor="#e0e0e0"
+        android:pathData="M97.59,630l294.29,191.06l0,-340.85l-294.29,-191.06l0,340.85z" />
+    <path
+        android:fillColor="#f5f5f5"
+        android:pathData="M400.14,464.73l-293.19,-191.45l293.19,-156.31l295.39,156.31l-295.39,191.45z" />
+    <path
+        android:fillColor="#eee"
+        android:pathData="M106.95,273.28l-9.36,15.87l294.29,191.06l8.26,-15.48l-293.19,-191.45z" />
+    <path
+        android:fillColor="#e0e0e0"
+        android:pathData="M695.53,273.28l9.37,15.87l-294.29,191.06l-10.47,-15.48l295.39,-191.45z" />
+    <path
+        android:fillColor="#eee"
+        android:pathData="M391.88,480.21h18.73v340.85h-18.73z" />
+    <path
+        android:fillColor="#f5f5f5"
+        android:pathData="M400.14,464.73l-8.26,15.48l18.73,0l-10.47,-15.48z" />
+    <path
+        android:fillColor="#78c257"
+        android:pathData="M326.53,254.89a16.9,28.71 97.07,1 0,4.16 -33.54a16.9,28.71 97.07,1 0,-4.16 33.54z" />
+    <path
+        android:fillColor="#78c257"
+        android:pathData="M537.57,298.78a16.9,28.71 97.07,1 0,4.16 -33.54a16.9,28.71 97.07,1 0,-4.16 33.54z" />
+    <path
+        android:fillColor="#78c257"
+        android:pathData="M397.17,213.3a16.9,28.71 97.07,1 0,4.16 -33.54a16.9,28.71 97.07,1 0,-4.16 33.54z" />
+    <path
+        android:fillColor="#78c257"
+        android:pathData="M396.31,381.95a16.9,28.71 97.07,1 0,4.16 -33.54a16.9,28.71 97.07,1 0,-4.16 33.54z" />
+    <path
+        android:fillColor="#78c257"
+        android:pathData="M255.91,296.47a16.9,28.71 97.07,1 0,4.16 -33.54a16.9,28.71 97.07,1 0,-4.16 33.54z" />
+    <path
+        android:fillColor="#78c257"
+        android:pathData="M466.93,340.37a16.9,28.71 97.07,1 0,4.16 -33.54a16.9,28.71 97.07,1 0,-4.16 33.54z" />
+    <path
+        android:fillColor="#78c257"
+        android:pathData="M230,563.64a30.12,16.11 53.82,1 0,26.01 -19.02a30.12,16.11 53.82,1 0,-26.01 19.02z" />
+    <path
+        android:fillColor="#78c257"
+        android:pathData="M312.02,533.78a30.12,16.11 53.82,1 0,26.01 -19.02a30.12,16.11 53.82,1 0,-26.01 19.02z" />
+    <path
+        android:fillColor="#78c257"
+        android:pathData="M147.96,593.48a30.12,16.11 53.82,1 0,26.01 -19.02a30.12,16.11 53.82,1 0,-26.01 19.02z" />
+    <path
+        android:fillColor="#78c257"
+        android:pathData="M483.54,554.83a30.12,16.11 126.18,1 0,35.56 -48.62a30.12,16.11 126.18,1 0,-35.56 48.62z" />
+    <path
+        android:fillColor="#78c257"
+        android:pathData="M618.75,604.04a30.12,16.11 126.18,1 0,35.56 -48.62a30.12,16.11 126.18,1 0,-35.56 48.62z" />
+</vector>

--- a/app/src/main/res/drawable/empty_dice.xml
+++ b/app/src/main/res/drawable/empty_dice.xml
@@ -1,0 +1,27 @@
+<!--
+  ~ Copyright 2018, The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="200dp"
+    android:height="250dp"
+    android:viewportWidth="800"
+    android:viewportHeight="1000">
+
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M0,0l0,0z" />
+
+</vector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -7,13 +7,13 @@
     android:layout_gravity="center_vertical"
     tools:context=".MainActivity">
 
-    <TextView
-        android:id="@+id/result_text"
+    <ImageView
+        android:id="@+id/dice_image"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="1"
         android:layout_gravity="center_horizontal"
-        android:textSize="30sp"/>
+        android:src="@drawable/empty_dice"
+        tools:src="@drawable/dice_1"/>
     
     <Button
         android:id="@+id/roll_button"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
@@ -12,7 +13,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_horizontal"
-        android:src="@drawable/empty_dice"
+        app:srcCompat="@drawable/empty_dice"
         tools:src="@drawable/dice_1"/>
     
     <Button

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.71'
+    ext.kotlin_version = '1.3.0'
     repositories {
         google()
         jcenter()
         
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.0-alpha13'
+        classpath 'com.android.tools.build:gradle:3.3.0-rc03'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
- Android Studio 3.3 RC3に対応
- サイコロの画像を追加
- テキストの代わりにサイコロの画像が表示されるようにする
- 初期画面ではサイコロの画像は表示させない
- API Version 21 未満でもVector画像に対応